### PR TITLE
Fix ToastProvider placement to satisfy Telegram UI AppRoot requirement

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -47,12 +47,14 @@ function AppContent(): JSX.Element {
 
   return (
     <AppRoot>
-      <HeaderBar />
-      <DemoBanner visible={!isTelegram} />
-      <div style={{ paddingBottom: 24 }}>
-        <AppRouter />
-      </div>
-      <NavigationControls />
+      <ToastProvider>
+        <HeaderBar />
+        <DemoBanner visible={!isTelegram} />
+        <div style={{ paddingBottom: 24 }}>
+          <AppRouter />
+        </div>
+        <NavigationControls />
+      </ToastProvider>
     </AppRoot>
   );
 }
@@ -65,9 +67,7 @@ export default function App(): JSX.Element {
       <TonConnectUIProvider manifestUrl={manifestUrl} uiPreferences={{ theme: "SYSTEM" }}>
         <TMAProvider>
           <ThemeProvider>
-            <ToastProvider>
-              <AppContent />
-            </ToastProvider>
+            <AppContent />
           </ThemeProvider>
         </TMAProvider>
       </TonConnectUIProvider>


### PR DESCRIPTION
## Summary
- move the toast provider inside the Telegram UI AppRoot so Snackbar renders within the required context

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4c24b0f6c8329928ba4fa56fb179b